### PR TITLE
fix Linux args, fix macOS exit, add macOS args, add conv.cal

### DIFF
--- a/cores/os/x86_64_linux.cal
+++ b/cores/os/x86_64_linux.cal
@@ -10,9 +10,9 @@ end
 
 version not LibC
 	inline __x86_64_program_init begin asm
-		"mov rax, [rsi + 8]"
+		"mov rax, [rsp + 16]"
 		"mov [__global___us____us__linux__us__argv], rax"
-		"mov rax, [rsi]"
+		"mov rax, [rsp + 8]"
 		"mov [__global___us____us__linux__us__argc], rax"
 	end end
 end

--- a/cores/os/x86_64_osx.cal
+++ b/cores/os/x86_64_osx.cal
@@ -1,4 +1,10 @@
-inline __x86_64_program_init begin end
+let addr __osx_argv
+let cell __osx_argc
+
+inline __x86_64_program_init begin asm
+	"mov [__global___us____us__osx__us__argc], edi"
+	"mov [__global___us____us__osx__us__argv], rsi"
+end end
 
 inline __x86_64_program_exit begin asm
 	"mov rax, 0x2000001"
@@ -17,8 +23,16 @@ version IO
 	end end
 end
 
+version Args
+	func core_get_arg begin
+		8 * __osx_argv + @
+	end
+
+	inline core_get_arg_length begin __osx_argc end
+end
+
 version Exit
-	func exir begin
+	func exit begin
 		__x86_64_pop_rdi
 		asm
 			"mov rax, 0x2000001"

--- a/std/conv.cal
+++ b/std/conv.cal
@@ -1,0 +1,22 @@
+include "array.cal"
+
+## ## parse_int
+## Parameters: Array* string
+##
+## Returns integer value represented by string
+func parse_int begin
+	let addr arr
+	-> arr
+
+	let cell pos
+	let cell len
+
+	0 -> pos
+	arr Array.length + @ -> len
+
+	0
+	while pos len < do
+		10 * pos arr a@ '0' - +
+		pos 1 + -> pos
+	end
+end


### PR DESCRIPTION
Just a bunch of changes that came up while adding Callisto to my [tak repo](https://github.com/soxfox42/tak).

- `argv` handling was broken on Linux (see the compiler PR for more)
- The macOS core had an `exir` function instead of `exit`.
- Added `argv` handling on macOS. Currently the compiler builds a program that still uses libc startup, so the code mostly matches the Linux libc version.
- Added a `parse_int` function.