### PR TITLE
Add arm64 Linux support

### DIFF
--- a/cores/cpu/arm64.cal
+++ b/cores/cpu/arm64.cal
@@ -1,0 +1,304 @@
+inline __arm64_pop_x0 begin asm
+	"ldr x0, [x19, #-8]!"
+end end
+
+inline __arm64_pop_x1 begin asm
+	"ldr x1, [x19, #-8]!"
+end end
+
+inline __arm64_pop_x2 begin asm
+	"ldr x2, [x19, #-8]!"
+end end
+
+inline __arm64_pop_x3 begin asm
+	"ldr x3, [x19, #-8]!"
+end end
+
+inline __arm64_pop_x4 begin asm
+	"ldr x4, [x19, #-8]!"
+end end
+
+inline __arm64_pop_x5 begin asm
+	"ldr x5, [x19, #-8]!"
+end end
+
+inline __arm64_pop_x9 begin asm
+	"ldr x9, [x19, #-8]!"
+end end
+
+inline __arm64_pop_x10 begin asm
+	"ldr x10, [x19, #-8]!"
+end end
+
+inline __arm64_pop_x11 begin asm
+	"ldr x11, [x19, #-8]!"
+end end
+
+inline __arm64_push_x0 begin asm
+	"str x0, [x19], #8"
+end end
+
+inline __arm64_push_x9 begin asm
+	"str x9, [x19], #8"
+end end
+
+inline __arm64_push_x10 begin asm
+	"str x10, [x19], #8"
+end end
+
+func = begin
+	__arm64_pop_x10
+	__arm64_pop_x9
+	asm
+		"cmp x9, x10"
+		"csetm x9, eq"
+	end
+	__arm64_push_x9
+end
+
+func > begin
+	__arm64_pop_x10
+	__arm64_pop_x9
+	asm
+		"cmp x9, x10"
+		"csetm x9, gt"
+	end
+	__arm64_push_x9
+end
+
+func >= begin
+	__arm64_pop_x10
+	__arm64_pop_x9
+	asm
+		"cmp x9, x10"
+		"csetm x9, ge"
+	end
+	__arm64_push_x9
+end
+
+func < begin
+	__arm64_pop_x10
+	__arm64_pop_x9
+	asm
+		"cmp x9, x10"
+		"csetm x9, lt"
+	end
+	__arm64_push_x9
+end
+
+func <= begin
+	__arm64_pop_x10
+	__arm64_pop_x9
+	asm
+		"cmp x9, x10"
+		"csetm x9, le"
+	end
+	__arm64_push_x9
+end
+
+func @ begin
+	__arm64_pop_x9
+	asm
+		"ldr x9, [x9]"
+	end
+	__arm64_push_x9
+end
+
+func ! begin
+	__arm64_pop_x10
+	__arm64_pop_x9
+	asm
+		"str x9, [x10]"
+	end
+end
+
+func b@ begin
+	__arm64_pop_x9
+	asm
+		"ldrb w9, [x9]"
+	end
+	__arm64_push_x9
+end
+
+func b! begin
+	__arm64_pop_x10
+	__arm64_pop_x9
+	asm
+		"strb w9, [x10]"
+	end
+end
+
+func w@ begin
+	__arm64_pop_x9
+	asm
+		"ldrh w9, [x9]"
+	end
+	__arm64_push_x9
+end
+
+func w! begin
+	__arm64_pop_x10
+	__arm64_pop_x9
+	asm
+		"strh w9, [x10]"
+	end
+end
+
+func d@ begin
+	__arm64_pop_x9
+	asm
+		"ldr w9, [x9]"
+	end
+	__arm64_push_x9
+end
+
+func d! begin
+	__arm64_pop_x10
+	__arm64_pop_x9
+	asm
+		"str w9, [x10]"
+	end
+end
+
+func dup begin
+	asm
+		"ldr x9, [x19, #-8]"
+	end
+	__arm64_push_x9
+end
+
+func drop begin asm
+	"sub x19, x19, #8"
+end end
+
+func swap begin
+	__arm64_pop_x10
+	__arm64_pop_x9
+	__arm64_push_x10
+	__arm64_push_x9
+end
+
+func + begin
+	__arm64_pop_x10
+	__arm64_pop_x9
+	asm
+		"add x9, x9, x10"
+	end
+	__arm64_push_x9
+end
+
+func s+ begin + end
+
+func - begin
+	__arm64_pop_x10
+	__arm64_pop_x9
+	asm
+		"sub x9, x9, x10"
+	end
+	__arm64_push_x9
+end
+
+func s- begin - end
+
+func * begin
+	__arm64_pop_x10
+	__arm64_pop_x9
+	asm
+		"mul x9, x9, x10"
+	end
+	__arm64_push_x9
+end
+
+func s* begin * end
+
+func / begin
+	__arm64_pop_x10
+	__arm64_pop_x9
+	asm
+		"udiv x9, x9, x10"
+	end
+	__arm64_push_x9
+end
+
+func s/ begin
+	__arm64_pop_x10
+	__arm64_pop_x9
+	asm
+		"sdiv x9, x9, x10"
+	end
+	__arm64_push_x9
+end
+
+func % begin
+	__arm64_pop_x10
+	__arm64_pop_x9
+	asm
+		"udiv x11, x9, x10"
+		"msub x9, x11, x10, x9"
+	end
+	__arm64_push_x9
+end
+
+func s% begin
+	__arm64_pop_x10
+	__arm64_pop_x9
+	asm
+		"sdiv x11, x9, x10"
+		"mul x11, x11, x10"
+		"sub x9, x9, x11"
+	end
+	__arm64_push_x9
+end
+
+func and begin
+	__arm64_pop_x10
+	__arm64_pop_x9
+	asm
+		"and x9, x9, x10"
+	end
+	__arm64_push_x9
+end
+
+func or begin
+	__arm64_pop_x10
+	__arm64_pop_x9
+	asm
+		"orr x9, x9, x10"
+	end
+	__arm64_push_x9
+end
+
+func xor begin
+	__arm64_pop_x10
+	__arm64_pop_x9
+	asm
+		"eor x9, x9, x10"
+	end
+	__arm64_push_x9
+end
+
+func not begin
+	__arm64_pop_x9
+	asm
+		"mvn x9, x9"
+	end
+	__arm64_push_x9
+end
+
+func << begin
+	__arm64_pop_x10
+	__arm64_pop_x9
+	asm
+		"lsl x9, x9, x10"
+	end
+	__arm64_push_x9
+end
+
+func >> begin
+	__arm64_pop_x10
+	__arm64_pop_x9
+	asm
+		"lsr x9, x9, x10"
+	end
+	__arm64_push_x9
+end

--- a/cores/os/arm64_linux.cal
+++ b/cores/os/arm64_linux.cal
@@ -1,0 +1,262 @@
+let addr __linux_argv
+let cell __linux_argc
+
+inline __arm64_program_init begin asm
+	"add x9, sp, #8"
+	"ldr x10, =__global___us____us__linux__us__argv"
+	"str x9, [x10]"
+	"ldr x9, [sp]"
+	"ldr x10, =__global___us____us__linux__us__argc"
+	"str x9, [x10]"
+end end
+
+inline __arm64_program_exit begin asm
+	"mov x8, #93"
+	"mov x0, #0"
+	"svc #0"
+end end
+
+# src, dest, len
+inline __memcpy begin
+	__arm64_pop_x11
+	__arm64_pop_x10
+	__arm64_pop_x9
+	asm
+		"1:"
+		"ldrb w12, [x9], #1"
+		"strb w12, [x10], #1"
+		"subs x11, x11, #1"
+		"bne 1b"
+	end
+end
+
+version IO
+	func printch begin asm
+		"sub x19, x19, #8"
+		"mov x8, #64"
+		"mov x0, #1"
+		"mov x1, x19"
+		"mov x2, #1"
+		"svc #0"
+	end end
+end
+
+version File
+	const FILE_READ  1
+	const FILE_WRITE 2
+
+	const SEEK_SET   0
+	const SEEK_CUR   1
+	const SEEK_END   2
+
+	const __linux_O_RDONLY 0
+	const __linux_O_WRONLY 1
+	const __linux_O_RDWR   2
+	const __linux_O_CREAT  64
+	const __linux_AT_FDCWD -100
+
+	const __linux_default_mode 0o666
+
+	struct File
+		cell fd
+	end
+
+	let File stdin
+	let File stdout
+	let File stderr
+	0 &stdin !
+	1 &stdout !
+	2 &stderr !
+
+	func open_file begin
+		let addr path
+		let cell mode
+		-> mode
+		-> path
+
+		let array 4096 u8 pathBuf
+
+		path Array.elements + @
+		&pathBuf
+		path @
+		__memcpy
+
+		let cell flags
+
+		if FILE_READ FILE_WRITE or mode = then
+			__linux_O_RDWR __linux_O_CREAT or -> flags
+		elseif FILE_READ mode = then
+			__linux_O_RDONLY -> flags
+		elseif FILE_WRITE mode = then
+			__linux_O_WRONLY __linux_O_CREAT or -> flags
+		end
+
+		__linux_AT_FDCWD
+		&pathBuf
+		flags
+		__linux_default_mode
+
+		__arm64_pop_x3
+		__arm64_pop_x2
+		__arm64_pop_x1
+		__arm64_pop_x0
+		asm
+			"mov x8, #56" # openat syscall
+			"svc #0"
+		end
+		__arm64_push_x0
+	end
+
+	func close_file begin
+		@ __arm64_pop_x0 # FD
+		asm
+			"mov x8, #57" # Close
+			"svc #0"
+		end
+	end
+
+	func file< begin
+		!
+	end
+
+	func file@ begin
+		__arm64_pop_x2   # Length
+		__arm64_pop_x1   # Buffer
+		@ __arm64_pop_x0 # Fd
+
+		asm
+			"mov x8, #63" # read
+			"svc #0"
+		end
+	end
+
+	func file! begin
+		__arm64_pop_x2   # Length
+		__arm64_pop_x1   # Buffer
+		@ __arm64_pop_x0 # Fd
+
+		asm
+			"mov x8, #64" # write
+			"svc #0"
+		end
+
+		__arm64_push_x0
+	end
+
+	func file_seek begin
+		__arm64_pop_x2   # Whence
+		__arm64_pop_x1   # Offset
+		@ __arm64_pop_x0 # Fd
+
+		asm
+			"mov x8, #62" # lseek
+			"svc #0"
+		end
+	end
+
+	func file_peek begin
+		@ __arm64_pop_x0
+		asm
+			"mov x1, #0"
+			"mov x2, #1" # SEEK_CUR
+			"mov x8, #62" # lseek
+			"svc #0"
+		end
+		__arm64_push_x0
+	end
+end
+
+version Args
+	func core_get_arg begin
+		8 * __linux_argv + @
+	end
+
+	inline core_get_arg_length begin __linux_argc end
+end
+
+version Time
+	struct __linux_timeval
+		cell sec
+		cell usec
+	end
+
+	func get_epoch_time begin
+		let __linux_timeval tv
+		&tv
+		__arm64_pop_x0
+		asm
+			"mov x8, #169" # gettimeofday
+			"mov x1, #0"
+			"svc #0"
+		end
+		&tv @
+	end
+end
+
+version Heap
+	version LibC
+		extern C addr malloc usize end
+		extern C void free addr end
+	end
+
+	version not LibC
+		const __linux_PROT_READ     1
+		const __linux_PROT_WRITE    2
+		const __linux_MAP_PRIVATE   2
+		const __linux_MAP_ANONYMOUS 32
+
+		func __linux_mmap begin
+			__arm64_pop_x5 # pgoff
+			__arm64_pop_x4 # fd
+			__arm64_pop_x3 # flags
+			__arm64_pop_x2 # prot
+			__arm64_pop_x1 # len
+			__arm64_pop_x0 # addr
+
+			asm
+				"mov x8, #222" # mmap syscall
+				"svc #0"
+			end
+
+			__arm64_push_x0
+		end
+
+		func malloc begin
+			let cell sz
+			-> sz
+
+			0 sz 8 + __linux_PROT_READ __linux_PROT_WRITE or
+			__linux_MAP_PRIVATE __linux_MAP_ANONYMOUS or -1 0 __linux_mmap
+
+			dup sz swap ! # write size
+			8 +
+		end
+
+		func __linux_munmap begin
+			__arm64_pop_x1 # length
+			__arm64_pop_x0 # addr
+
+			asm
+				"mov x0, #215" # munmap syscall
+				"svc #0"
+			end
+
+			__arm64_push_x0
+		end
+
+		func free begin
+			dup 8 - @ swap 8 - swap 8 + __linux_munmap drop
+		end
+	end
+end
+
+version Exit
+	func exit begin
+		asm
+			"ldr x0, [x19, #-8]!"
+			"mov x8, #93"
+			"svc #0"
+		end
+	end
+end
+

--- a/cores/os/x86_64_linux.cal
+++ b/cores/os/x86_64_linux.cal
@@ -10,7 +10,7 @@ end
 
 version not LibC
 	inline __x86_64_program_init begin asm
-		"mov rax, [rsp + 16]"
+		"lea rax, [rsp + 16]"
 		"mov [__global___us____us__linux__us__argv], rax"
 		"mov rax, [rsp + 8]"
 		"mov [__global___us____us__linux__us__argc], rax"
@@ -154,7 +154,7 @@ version File
 
 		let cell modeFlag
 
-		if FILE_READ FILE_WRITE and mode = then
+		if FILE_READ FILE_WRITE or mode = then
 			&pathBytes __linux_create_file
 			__linux_const_O_RDWR -> modeFlag
 		elseif FILE_READ mode = then
@@ -239,33 +239,8 @@ version File
 end
 
 version Args
-	version LibC
-		func core_get_arg begin
-			8 * __linux_argv + @
-		end
-	end
-
-	version not LibC
-		func core_get_arg begin
-			let cell which
-			let cell counter
-			let addr args
-			dup -> which
-			-> counter
-			__linux_argv -> args
-
-			if which 0 = then args return end
-
-			while true do
-				if args b@ 0 = then
-					counter 1 - -> counter
-
-					if counter 0 = then args 1 + return end
-				end
-
-				args 1 + -> args
-			end
-		end
+	func core_get_arg begin
+		8 * __linux_argv + @
 	end
 
 	inline core_get_arg_length begin __linux_argc end
@@ -342,7 +317,7 @@ version Heap
 		end
 
 		func free begin
-			dup 8 - @ swap 8 - swap 8 + __linux_munmap
+			dup 8 - @ swap 8 - swap 8 + __linux_munmap drop
 		end
 	end
 end

--- a/cores/select.cal
+++ b/cores/select.cal
@@ -10,6 +10,10 @@ version x86_64
 	include "cpu/x86_64.cal"
 end
 
+version arm64
+	include "cpu/arm64.cal"
+end
+
 version UXN
 	include "uxn.cal"
 end
@@ -26,6 +30,12 @@ version x86_64
 
 	version OSX
 		include "os/x86_64_osx.cal"
+	end
+end
+
+version arm64
+	version Linux
+		include "os/arm64_linux.cal"
 	end
 end
 

--- a/std/array.cal
+++ b/std/array.cal
@@ -100,7 +100,7 @@ func a! begin
 			b!
 		elseif arr Array.memberSize + @ 2 = then
 			version 16Bit
-				w@
+				w!
 			end
 			version not 16Bit
 				# TODO!!!

--- a/std/io.cal
+++ b/std/io.cal
@@ -72,7 +72,7 @@ end
 ##
 ## Prints a new line to stdout
 func new_line begin
-	'\r' '\n' printch printch
+	'\r' printch '\n' printch
 end
 
 ## ## printf
@@ -96,7 +96,7 @@ func printf begin
 	while i fmt @ < do
 		if i fmt a@ '%' = then
 			i 1 + -> i
-			i fmt @ a@ -> ch
+			i fmt a@ -> ch
 
 			if ch 's' = then
 				printstr


### PR DESCRIPTION
This is the stdlib part of my arm64 support patch. Like the compiler PR, I've rolled in a few general fixes that I made along the way.

Support in the standard library is mostly modeled after the x86_64 code, with a few syscalls replaced where the original was not present on arm64.